### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/compiler/grunt-thrift-generator.js
+++ b/compiler/grunt-thrift-generator.js
@@ -8,7 +8,7 @@ var util = require('../common/utils');
 var Preconditions = require('precondition');
 var path = require('path');
 var fs = require('fs-extra');
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 var thriftServiceExtractor = require('./thrift-service-extractor');
 
 module.exports = function (grunt) {

--- a/package.json
+++ b/package.json
@@ -10,18 +10,17 @@
     "url": "https://github.com/massaroni/grunt-angularjs-thrift-0.9"
   },
   "dependencies": {
-    "precondition": "1.0.0",
     "concat-files": "0.1.0",
     "fs-extra": "0.12.0",
     "merge": "1.2.0",
     "path": "0.11.14",
-    "shelljs": "0.3.0",
+    "precondition": "1.0.0",
     "recursive-readdir": "1.2.1",
-    "node-uuid": "1.4.2",
-    "underscore": "1.6.0"
+    "shelljs": "0.3.0",
+    "underscore": "1.6.0",
+    "uuid": "^3.0.0"
   },
-  "devDependencies": {
-  },
+  "devDependencies": {},
   "engines": {
     "node": ">=0.8.0"
   }


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.